### PR TITLE
correct payment types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Swapped the request data on line 37/38 so expired date is taking the expired date from the request

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `http://localhost:8000/paymenttypes` Creates a new payment type

```json
    {
        "merchant_name": "Chime",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2035-12-01",
        "create_date": "2001-03-11"
    }
```

**Response**

HTTP/1.1 201 Created

```json
{
    "id": 5,
    "url": "http://localhost:8000/paymenttypes/5",
    "merchant_name": "Chime",
    "account_number": "fj0398fjw0g89434",
    **"expiration_date": "2035-12-01",**
    "create_date": "2001-03-11"
}
```

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] using postman send a POST to this url `http://localhost:8000/paymenttypes` using the json under request and being given back the json under response. Make sure the expiration_date is the same between the request and response.


## Related Issues

- Fixes #19 